### PR TITLE
Cmake and Windows port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,15 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
 
 set(LIBEVENT_DIR "" CACHE PATH "Location of Libevent build try if you have built it yourself. If this is no set, the system version will be used")
 
+if (WIN32)
+    set(PTHREADS_WIN32_DIR "" CACHE PATH "Location for pthreads-win32 pre-built libraries root 'c:/path/to/pthreads-w32-2-9-1-release/Pre-built.2'. Get ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip or latest release")
+endif()
+
+if (MSVC)
+    # Turn off stupid microsoft security warnings.
+    add_definitions(-D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE)
+endif(MSVC)
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
@@ -22,12 +31,19 @@ endif()
 # Find libs
 #
 
+if (WIN32)
+    list(APPEND WEBSOCK_DEPS ws2_32.lib)
+endif()
+
+# OpenSSL
 find_package(OpenSSL)
 
 if (OPENSSL_FOUND)
     set(WEBSOCK_HAVE_SSL 1)
+    include_directories("${OPENSSL_INCLUDE_DIR}")
 endif()
 
+# Libevent
 if (LIBEVENT_DIR)
     find_package(Libevent REQUIRED CONFIG NO_DEFAULT_PATH NO_CMAKE_PACKAGE_REGISTRY
                 PATHS ${LIBEVENT_DIR})
@@ -36,10 +52,29 @@ else()
 endif()
 
 list(APPEND WEBSOCK_DEPS ${LIBEVENT_LIBRARIES})
+include_directories("${LIBEVENT_INCLUDE_DIRS}")
 
-find_package(Threads)
+# Pthreads
+if (WIN32)
+    if (NOT PTHREADS_WIN32_DIR)
+        message(FATAL_ERROR "You need to specify -DPTHREADS_WIN32_DIR")
+    endif()
+
+    set(Threads_INCLUDE_DIR "${PTHREADS_WIN32_DIR}/include")
+    set(CMAKE_THREAD_LIBS_INIT
+        User32.lib 
+        Shell32.lib 
+        iphlpapi.lib
+        "${PTHREADS_WIN32_DIR}/lib/x86/pthreadVC2.lib")
+    set(PTHREAD_WIN32_DLL_PATH "${PTHREADS_WIN32_DIR}/dll/x86/pthreadVC2.dll")
+else()
+    find_package(Threads)
+endif()
+
+include_directories(${Threads_INCLUDE_DIR})
 list(APPEND WEBSOCK_DEPS ${CMAKE_THREAD_LIBS_INIT})
 
+# Require for clock_get_time
 if (LINUX)
     list(APPEND WEBSOCK_DEPS rt)
 endif()
@@ -59,15 +94,15 @@ set(SRC_LIB
     src/websock.c)
 
 set(HDR_LIB_PRIVATE
-    src/sha1.h)
+    src/sha1.h
+    src/utf.h)
 
 set(HDR_LIB_PUBLIC
     src/websock.h
     src/types.h
     src/api.h
     src/default_callbacks.h
-    src/frames.h
-    src/utf.h
+    src/frames.h    
     src/util.h)
 
 if (WEBSOCK_HAVE_SSL)
@@ -88,8 +123,7 @@ configure_file("${PROJECT_SOURCE_DIR}/websock_config.h.cmake" "${PROJECT_BINARY_
 
 include_directories(
     "${PROJECT_SOURCE_DIR}"
-    "${PROJECT_BINARY_DIR}/include"
-    "${LIBEVENT_INCLUDE_DIRS}")
+    "${PROJECT_BINARY_DIR}/include")
 
 add_library(websock ${SRC_LIB} ${HDR_LIB_PRIVATE} ${HDR_LIB_PUBLIC})
 
@@ -101,3 +135,9 @@ target_link_libraries(websock ${WEBSOCK_DEPS})
 add_executable(autobahn-echo examples/autobahn-echo.c)
 target_link_libraries(autobahn-echo websock)
 
+if (WIN32)
+    add_custom_command(
+        TARGET autobahn-echo 
+        POST_BUILD 
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PTHREAD_WIN32_DLL_PATH} $<TARGET_FILE_DIR:autobahn-echo> VERBATIM)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,17 @@ find_package(OpenSSL)
 
 if (OPENSSL_FOUND)
     set(WEBSOCK_HAVE_SSL 1)
-    #add_definitions(-DWEBSOCK_HAVE_SSL)
 endif()
 
 find_package(Libevent REQUIRED)
+list(APPEND WEBSOCK_DEPS ${LIBEVENT_LIBRARIES})
+
 find_package(Threads)
+list(APPEND WEBSOCK_DEPS ${CMAKE_THREAD_LIBS_INIT})
+
+if (LINUX)
+    list(APPEND WEBSOCK_DEPS rt)
+endif()
 
 set(SRC_LIB
     src/api.c
@@ -39,6 +45,10 @@ set(HDR_LIB_PUBLIC
     src/utf.h
     src/util.h)
 
+if (WEBSOCK_HAVE_SSL)
+    list(APPEND SRC_LIB src/openssl.c)
+endif()
+
 source_group("Headers Lib Private"  FILES ${HDR_LIB_PRIVATE})
 source_group("Headers Lib Public"   FILES ${HDR_LIB_PUBLIC})
 source_group("Source Lib"           FILES ${SRC_LIB})
@@ -53,15 +63,16 @@ configure_file("${PROJECT_SOURCE_DIR}/websock_config.h.cmake" "${PROJECT_BINARY_
 
 include_directories(
     "${PROJECT_SOURCE_DIR}"
-    "${PROJECT_BINARY_DIR}/include")
+    "${PROJECT_BINARY_DIR}/include"
+    "${LIBEVENT_INCLUDE_DIR}")
 
 add_library(websock ${SRC_LIB} ${HDR_LIB_PRIVATE} ${HDR_LIB_PUBLIC})
 
-target_link_libraries(websock ${LIBEVENT_LIBRARIES} event_extra rt ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(websock ${WEBSOCK_DEPS})
 
 #
 # Examples
 #
 add_executable(autobahn-echo examples/autobahn-echo.c)
-target_link_libraries(autobahn-echo websock ${LIBEVENT_LIBRARIES} rt ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(autobahn-echo websock ${WEBSOCK_DEPS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,24 @@ project(libwebsock)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
 
+set(LIBEVENT_DIR "" CACHE PATH "Location of Libevent build try if you have built it yourself. If this is no set, the system version will be used")
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+
+if (APPLE)
+    # Get rid of deprecated warnings for OpenSSL on OSX 10.7 and greater.
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=deprecated-declarations -Wno-deprecated-declarations")
+    # Get rid of "clang: warning: argument unused during compilation: -I etc
+    if ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments")
+    endif()
+endif()
+
+#
+# Find libs
+#
 
 find_package(OpenSSL)
 
@@ -13,7 +28,13 @@ if (OPENSSL_FOUND)
     set(WEBSOCK_HAVE_SSL 1)
 endif()
 
-find_package(Libevent REQUIRED)
+if (LIBEVENT_DIR)
+    find_package(Libevent REQUIRED CONFIG NO_DEFAULT_PATH NO_CMAKE_PACKAGE_REGISTRY
+                PATHS ${LIBEVENT_DIR})
+else()
+    find_package(Libevent REQUIRED)
+endif()
+
 list(APPEND WEBSOCK_DEPS ${LIBEVENT_LIBRARIES})
 
 find_package(Threads)
@@ -22,6 +43,10 @@ list(APPEND WEBSOCK_DEPS ${CMAKE_THREAD_LIBS_INIT})
 if (LINUX)
     list(APPEND WEBSOCK_DEPS rt)
 endif()
+
+#
+# Sources
+#
 
 set(SRC_LIB
     src/api.c
@@ -55,7 +80,7 @@ source_group("Source Lib"           FILES ${SRC_LIB})
 
 foreach (HDR ${HDR_LIB_PUBLIC})
     get_filename_component(HDR_NAME ${HDR} NAME)
-    message("${PROJECT_SOURCE_DIR}/${HDR} -> ${PROJECT_BINARY_DIR}/include/websock/${HDR_NAME}")
+    #message("${PROJECT_SOURCE_DIR}/${HDR} -> ${PROJECT_BINARY_DIR}/include/websock/${HDR_NAME}")
     configure_file("${PROJECT_SOURCE_DIR}/${HDR}" "${PROJECT_BINARY_DIR}/include/websock/${HDR_NAME}" COPYONLY)
 endforeach()
 
@@ -64,7 +89,7 @@ configure_file("${PROJECT_SOURCE_DIR}/websock_config.h.cmake" "${PROJECT_BINARY_
 include_directories(
     "${PROJECT_SOURCE_DIR}"
     "${PROJECT_BINARY_DIR}/include"
-    "${LIBEVENT_INCLUDE_DIR}")
+    "${LIBEVENT_INCLUDE_DIRS}")
 
 add_library(websock ${SRC_LIB} ${HDR_LIB_PRIVATE} ${HDR_LIB_PUBLIC})
 
@@ -74,5 +99,5 @@ target_link_libraries(websock ${WEBSOCK_DEPS})
 # Examples
 #
 add_executable(autobahn-echo examples/autobahn-echo.c)
-target_link_libraries(autobahn-echo websock ${WEBSOCK_DEPS})
+target_link_libraries(autobahn-echo websock)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 2.6) 
+project(libwebsock)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+
+find_package(OpenSSL)
+
+if (OPENSSL_FOUND)
+    set(WEBSOCK_HAVE_SSL 1)
+    #add_definitions(-DWEBSOCK_HAVE_SSL)
+endif()
+
+find_package(Libevent REQUIRED)
+find_package(Threads)
+
+set(SRC_LIB
+    src/api.c
+    src/base64.c
+    src/default_callbacks.c
+    src/frames.c
+    src/sha1.c
+    src/utf.c
+    src/util.c
+    src/websock.c)
+
+set(HDR_LIB_PRIVATE
+    src/sha1.h)
+
+set(HDR_LIB_PUBLIC
+    src/websock.h
+    src/types.h
+    src/api.h
+    src/default_callbacks.h
+    src/frames.h
+    src/utf.h
+    src/util.h)
+
+source_group("Headers Lib Private"  FILES ${HDR_LIB_PRIVATE})
+source_group("Headers Lib Public"   FILES ${HDR_LIB_PUBLIC})
+source_group("Source Lib"           FILES ${SRC_LIB})
+
+foreach (HDR ${HDR_LIB_PUBLIC})
+    get_filename_component(HDR_NAME ${HDR} NAME)
+    message("${PROJECT_SOURCE_DIR}/${HDR} -> ${PROJECT_BINARY_DIR}/include/websock/${HDR_NAME}")
+    configure_file("${PROJECT_SOURCE_DIR}/${HDR}" "${PROJECT_BINARY_DIR}/include/websock/${HDR_NAME}" COPYONLY)
+endforeach()
+
+configure_file("${PROJECT_SOURCE_DIR}/websock_config.h.cmake" "${PROJECT_BINARY_DIR}/include/websock/websock_config.h")
+
+include_directories(
+    "${PROJECT_SOURCE_DIR}"
+    "${PROJECT_BINARY_DIR}/include")
+
+add_library(websock ${SRC_LIB} ${HDR_LIB_PRIVATE} ${HDR_LIB_PUBLIC})
+
+target_link_libraries(websock ${LIBEVENT_LIBRARIES} event_extra rt ${CMAKE_THREAD_LIBS_INIT})
+
+#
+# Examples
+#
+add_executable(autobahn-echo examples/autobahn-echo.c)
+target_link_libraries(autobahn-echo websock ${LIBEVENT_LIBRARIES} rt ${CMAKE_THREAD_LIBS_INIT})
+

--- a/README.md
+++ b/README.md
@@ -28,6 +28,73 @@ Current Travis CI Build Status:
 * IPv6 support
 * No failures on Autobahn Test suite
 
+## Compiling
+
+### Unix
+
+Using the autotools project:
+
+```bash
+$ sudo apt-get install autotools-dev automake libevent-dev
+$ ./autogen.sh
+$ ./configure
+$ make
+```
+
+Using [CMake][8]:
+
+```bash
+$ mkdir build && cd build
+$ cmake ..
+$ make
+```
+
+### Windows
+
+To compile on Windows using CMake, do the following in *git bash*:
+
+```bash
+#
+# Or place this wherever you want to build...
+#
+$ cd /c
+$ mkdir dev && cd dev
+
+#
+# Download latest OpenSSL Win32 binary: http://slproweb.com/products/Win32OpenSSL.html
+#
+$ curl -O http://slproweb.com/download/Win32OpenSSL-1_0_1L.exe
+$ /c/Windows/System32/cmd.exe
+$ Win32OpenSSL-1_0_1L.exe /silent /verysilent /sp- /suppressmsgboxes
+$ exit
+
+#
+# Build Libevent
+#
+$ git clone git@github.com:nmathewson/Libevent.git
+$ cd Libevent
+$ mkdir build && cd build
+$ cmake ..
+$ cmake --build .
+$ cd ../..
+
+#
+# Get Win32 pthreads.
+#
+$ curl -O ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip
+$ unzip -d pthreads-win32 pthreads-w32-2-9-1-release.zip
+
+#
+# Build libwebsock
+#
+$ git clone git@github.com:payden/libwebsock.git
+$ cd libwebsock
+$ mkdir build && cd build
+$ cmake -DPTHREADS_WIN32_DIR=/c/dev/pthreads-win32/Pre-built.2/ -DLIBEVENT_DIR=/c/dev/Libevent/build ..
+$ start libwebsock.sln  # Use Visual Studio GUI to build.
+$ cmake --build .       # Or build via command line.
+```
+
  [1]: https://github.com/payden/libwebsock/blob/master/examples/echo.c
  [2]: http://libevent.org
  [3]: http://paydensutherland.com/autobahn
@@ -35,3 +102,4 @@ Current Travis CI Build Status:
  [5]: https://travis-ci.org/payden/libwebsock
  [6]: https://github.com/payden/libwebsock/wiki/Installation
  [7]: https://github.com/payden/libwebsock/wiki/API
+ [8]: http://www.cmake.org/

--- a/cmake/FindLibevent.cmake
+++ b/cmake/FindLibevent.cmake
@@ -1,0 +1,34 @@
+# - Find LibEvent (a cross event library)
+# This module defines
+# LIBEVENT_INCLUDE_DIR, where to find LibEvent headers
+# LIBEVENT_LIBRARIES, Libevent libraries
+# LibEvent_FOUND, If false, do not try to use libevent
+
+set(LibEvent_EXTRA_PREFIXES /usr/local /opt/local "$ENV{HOME}" /usr/lib)
+foreach(prefix ${LibEvent_EXTRA_PREFIXES})
+	list(APPEND LibEvent_INCLUDE_PATHS "${prefix}/include" "${prefix}/")
+	list(APPEND LIBEVENT_LIB_DIR_PATHS "${prefix}/lib")
+endforeach()
+
+find_path(LIBEVENT_INCLUDE_DIR event2/event.h)
+find_library(LIBEVENT_LIB NAMES libevent.a)
+find_library(LIBEVENT_PTHREADS_LIB NAMES libevent_pthreads.a)
+find_library(LIBEVENT_CORE_LIB NAMES libevent_core.a)
+find_library(LIBEVENT_EXTRA_LIB NAMES libevent_extra.a)
+
+set(LIBEVENT_LIBRARIES
+    ${LIBEVENT_LIB}
+    ${LIBEVENT_PTHREADS_LIB}
+    ${LIBEVENT_CORE_LIB}
+    ${LIBEVENT_EXTRA_LIB})
+
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibEvent DEFAULT_MSG
+                                  LIBEVENT_LIBRARIES
+                                  LIBEVENT_INCLUDE_DIR)
+
+mark_as_advanced(
+    LIBEVENT_LIBRARIES
+    LIBEVENT_INCLUDE_DIR
+  )

--- a/cmake/FindLibevent.cmake
+++ b/cmake/FindLibevent.cmake
@@ -10,7 +10,7 @@ foreach(prefix ${LibEvent_EXTRA_PREFIXES})
 	list(APPEND LIBEVENT_LIB_DIR_PATHS "${prefix}/lib")
 endforeach()
 
-find_path(LIBEVENT_INCLUDE_DIR event2/event.h)
+find_path(LIBEVENT_INCLUDE_DIRS event2/event.h)
 find_library(LIBEVENT_LIB NAMES libevent.a)
 find_library(LIBEVENT_PTHREADS_LIB NAMES libevent_pthreads.a)
 find_library(LIBEVENT_CORE_LIB NAMES libevent_core.a)
@@ -26,9 +26,9 @@ set(LIBEVENT_LIBRARIES
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LibEvent DEFAULT_MSG
                                   LIBEVENT_LIBRARIES
-                                  LIBEVENT_INCLUDE_DIR)
+                                  LIBEVENT_INCLUDE_DIRS)
 
 mark_as_advanced(
     LIBEVENT_LIBRARIES
-    LIBEVENT_INCLUDE_DIR
+    LIBEVENT_INCLUDE_DIRS
   )

--- a/src/openssl.c
+++ b/src/openssl.c
@@ -17,7 +17,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
  */
 
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include "websock.h"
 
@@ -125,14 +127,14 @@ libwebsock_bind_ssl_real(libwebsock_context *ctx, char *listen_host, char *port,
       perror("socket");
       continue;
     }
-    if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) == -1) {
+    if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (char *)&yes, sizeof(int)) == -1) {
       perror("setsockopt");
       lws_free(ctx);
       exit(-1);
     }
     if (bind(sockfd, p->ai_addr, p->ai_addrlen) == -1) {
       perror("bind");
-      close(sockfd);
+	  evutil_closesocket(sockfd);
       continue;
     }
     break;

--- a/src/utf.c
+++ b/src/utf.c
@@ -24,7 +24,7 @@ static const uint8_t utf8d[] = {
   1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1, // s7..s8
 };
 
-uint32_t inline
+uint32_t
 decode(uint32_t* state, uint32_t* codep, uint32_t byte)
 {
   uint32_t type = utf8d[byte];

--- a/src/utf.h
+++ b/src/utf.h
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 
-uint32_t inline decode(uint32_t *state, uint32_t *codep, uint32_t byte);
+uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte);
 
 
 #endif /* UTF_H_ */

--- a/src/utf.h
+++ b/src/utf.h
@@ -22,6 +22,9 @@
 
 #include <stdint.h>
 
+#define UTF8_ACCEPT 0
+#define UTF8_REJECT 1
+
 uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte);
 
 

--- a/src/util.c
+++ b/src/util.c
@@ -18,9 +18,9 @@
  */
 
 #include "websock.h"
+#include "utf.h"
 
-#define UTF8_ACCEPT 0
-#define UTF8_REJECT 1
+pthread_mutex_t global_alloc_free_lock = PTHREAD_MUTEX_INITIALIZER;
 
 //these functions assume little endian machine as they're only used on windows
 uint16_t

--- a/src/websock.h
+++ b/src/websock.h
@@ -47,6 +47,10 @@
 #endif
 
 #ifdef _WIN32
+#define __func__ __FUNCTION__
+#ifndef snprintf
+#define snprintf _snprintf
+#endif
 #include <ws2tcpip.h>
 #endif
 
@@ -70,7 +74,6 @@
 #include "api.h"
 #include "frames.h"
 #include "default_callbacks.h"
-#include "utf.h"
 #include "util.h"
 
 
@@ -113,11 +116,7 @@
 #define STATE_RECEIVED_CLOSE_FRAME (1 << 7)
 #define STATE_FAILING_CONNECTION (1 << 8)
 
-//globals
-extern pthread_mutex_t global_alloc_free_lock;
-
-//function defs
-
+// function defs
 
 int libwebsock_send_fragment(libwebsock_client_state *state, const char *data, unsigned int len, int flags);
 void libwebsock_send_cleanup(const void *data, size_t len, void *arg);

--- a/websock_config.h.cmake
+++ b/websock_config.h.cmake
@@ -1,0 +1,2 @@
+
+#cmakedefine WEBSOCK_HAVE_SSL


### PR DESCRIPTION
Hello!

This is an initial port for Windows/CMake. It uses `pthreads-win32` for compatible threading stuff.

Tested on OSX, Windows 7 and Debian.

`SIGUSR*` does not exist on windows, so I simply commented those out... I'm not entirely clear on what significance that has in the code?

Currently the project only build the Autobahn test suite example, I have yet to actually test to run anything.

Minor note:
The current build instructions for windows requires a fix in the Libevent project which is in this pull request: https://github.com/nmathewson/Libevent/pull/116

So before that is merged, to be able to build one has to use my branch. Slight modification to the build instructions for windows to do that:

``` bash
...
$ git clone git@github.com:JoakimSoderberg/Libevent.git
$ cd Libevent
$ git checkout fix_build_tree_cmake_config
...
```
