### PR TITLE
Added pkg-config to libwebsock

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = src examples
+
+pkgconfig_DATA = libwebsock.pc
+

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,23 @@ AC_ARG_WITH([ssl],
   [AS_HELP_STRING([--without-ssl],[Disable building with SSL support])])
 
 
+# Check for pkg-config.
+PKG_PROG_PKG_CONFIG
+AC_ARG_VAR([PKG_CONFIG_PATH], "Additional directories for package discovery.")
+
+# Process options.
+#==============================================================================
+# Implement --with-pkgconfigdir and output ${pkgconfigdir}.
+#------------------------------------------------------------------------------
+AC_MSG_CHECKING([--with-pkgconfigdir option])
+AC_ARG_WITH([pkgconfigdir],
+    AS_HELP_STRING([--with-pkgconfigdir=DIR],
+        [Path to pkgconfig directory. @<:@default=${libdir}/pkgconfig@:>@]),
+    [pkgconfigdir=$withval],
+    [pkgconfigdir=${libdir}/pkgconfig])
+AC_MSG_RESULT([$pkgconfigdir])
+AC_SUBST([pkgconfigdir])
+
 
 # Checks for header files.
 AC_CHECK_HEADERS([netdb.h stdlib.h string.h sys/socket.h unistd.h])
@@ -68,5 +85,5 @@ AM_CONDITIONAL([HAVE_SSL], [test "x$have_ssl" = "xyes"])
 AC_DEFINE_UNQUOTED([WEBSOCK_PACKAGE_VERSION], ["$PACKAGE_VERSION"], [libwebsock version])
 AC_DEFINE_UNQUOTED([WEBSOCK_PACKAGE_STRING], ["$PACKAGE_STRING"], [libwebsock package string])
 AC_DEFINE_UNQUOTED([WEBSOCK_PACKAGE_NAME], ["$PACKAGE_NAME"], [libwebsock package name])
-AC_CONFIG_FILES([Makefile src/Makefile examples/Makefile])
+AC_CONFIG_FILES([Makefile libwebsock.pc src/Makefile examples/Makefile])
 AC_OUTPUT

--- a/libwebsock.pc.in
+++ b/libwebsock.pc.in
@@ -1,0 +1,38 @@
+###############################################################################
+#  Copyright (c) 2014-2015 libbitcoin developers (see COPYING).
+#
+#         GENERATED SOURCE CODE, DO NOT EDIT EXCEPT EXPERIMENTALLY
+#
+###############################################################################
+
+# Substitutions
+#==============================================================================
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+
+# Metadata
+#==============================================================================
+Name: libwebsock
+Description: C library for easy WebSockets server.
+URL: https://github.com/payden/libwebsock
+Version: @PACKAGE_VERSION@
+
+
+# Variables
+#==============================================================================
+# Dependencies that publish package configuration.
+#------------------------------------------------------------------------------
+# Requires: @icu_i18n_PKG@ @png_PKG@ @qrencode_PKG@ libsecp256k1 >= 0.0.1
+
+# Include directory and any other required compiler flags.
+#------------------------------------------------------------------------------
+# Cflags: -I${includedir} @icu@ @png@ @qrencode@ @boost_CPPFLAGS@ @pthread_CPPFLAGS@
+Cflags: -I${includedir}
+
+# Lib directory, lib and any required that do not publish pkg-config.
+#------------------------------------------------------------------------------
+Libs: -L${libdir} -lwebsock
+

--- a/src/config.h
+++ b/src/config.h
@@ -60,8 +60,7 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #define HAVE_UNISTD_H 1
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #define LT_OBJDIR ".libs/"
 
 /* Name of package */

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -59,8 +59,7 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #undef LT_OBJDIR
 
 /* Name of package */

--- a/src/utf.c
+++ b/src/utf.c
@@ -24,7 +24,7 @@ static const uint8_t utf8d[] = {
   1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1, // s7..s8
 };
 
-uint32_t inline
+uint32_t
 decode(uint32_t* state, uint32_t* codep, uint32_t byte)
 {
   uint32_t type = utf8d[byte];

--- a/src/utf.h
+++ b/src/utf.h
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 
-uint32_t inline decode(uint32_t *state, uint32_t *codep, uint32_t byte);
+uint32_t decode(uint32_t *state, uint32_t *codep, uint32_t byte);
 
 
 #endif /* UTF_H_ */

--- a/src/websock_config.h
+++ b/src/websock_config.h
@@ -2,8 +2,6 @@
 #ifndef WEBSOCK_CONFIG_H
 #define WEBSOCK_CONFIG_H 1
 
-#define LIBWEBSOCK_DEBUG 0
-
 #define WEBSOCK_PACKAGE_STRING "libwebsock 1.0.7"
 #define WEBSOCK_PACKAGE_VERSION "1.0.7"
 #define WEBSOCK_PACKAGE_NAME "libwebsock"


### PR DESCRIPTION
People can use the command $(pkg-config --cflags --libs libwebsock) for the compile options. This is used by many other libraries and programs in autoconf for detecting them at configure step.
